### PR TITLE
StyleNotDefined exception text changed to use STYLES instead of STYLE.

### DIFF
--- a/source/WMSGetMap.cpp
+++ b/source/WMSGetMap.cpp
@@ -89,7 +89,7 @@ void check_getmap_request_options(const SmartMet::Spine::HTTP::Request& theHTTPR
     if (!theHTTPRequest.getParameter("STYLES"))
     {
       SmartMet::Spine::Exception exception(BCP,
-                                           "STYLE-option must be defined, even if it is empty");
+                                           "STYLES-option must be defined, even if it is empty");
       exception.addParameter(WMS_EXCEPTION_CODE, WMS_STYLE_NOT_DEFINED);
       throw exception;
     }


### PR DESCRIPTION
STYLES parameter of a GetMap request is mandatory. STYLE parameter is not
defined in WMS 1.3.0 implemetation specification (OGC 06-042).

It is much easier to use the service if exception message gives direct answer for a problem.