### PR TITLE
Compat 202404

### DIFF
--- a/wms/IceMapLayer.cpp
+++ b/wms/IceMapLayer.cpp
@@ -376,7 +376,7 @@ void IceMapLayer::generate(CTPP::CDT& theGlobals, CTPP::CDT& theLayersCdt, State
       {
         if (result_item->geom && result_item->geom->IsEmpty() == 0)
         {
-          OGRSpatialReference* sr = result_item->geom->getSpatialReference();
+          const OGRSpatialReference* sr = result_item->geom->getSpatialReference();
 
           if (sr == nullptr)
           {
@@ -384,7 +384,12 @@ void IceMapLayer::generate(CTPP::CDT& theGlobals, CTPP::CDT& theLayersCdt, State
             result_item->geom->transformTo(projectionSR.get());
           }
           else
-            sr->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+          {
+            std::shared_ptr<OGRSpatialReference> newSR(
+              sr->Clone(), [] (OGRSpatialReference* ref) { ref->Release(); });
+            newSR->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+            result_item->geom->assignSpatialReference(newSR.get());
+          }
 
           handleResultItem(
               *result_item, filter, mapid, theGlobals, theLayersCdt, theGroupCdt, theState);

--- a/wms/IsobandLayer.cpp
+++ b/wms/IsobandLayer.cpp
@@ -51,14 +51,14 @@ std::string format_auto(const Isoband& isoband, const std::string& pattern)
   if (isoband.lolimit)
   {
     if (isoband.hilimit)
-      return fmt::format(pattern, *isoband.lolimit, *isoband.hilimit);
-    return fmt::format(pattern, *isoband.lolimit, "inf");
+      return fmt::format(fmt::runtime(pattern), *isoband.lolimit, *isoband.hilimit);
+    return fmt::format(fmt::runtime(pattern), *isoband.lolimit, "inf");
   }
 
   if (isoband.hilimit)
-    return fmt::format(pattern, "-inf", *isoband.hilimit);
+    return fmt::format(fmt::runtime(pattern), "-inf", *isoband.hilimit);
 
-  return fmt::format(pattern, "nan", "nan");
+  return fmt::format(fmt::runtime(pattern), "nan", "nan");
 }
 
 void apply_autoqid(std::vector<Isoband>& isobands, const std::string& pattern)

--- a/wms/IsolineLayer.cpp
+++ b/wms/IsolineLayer.cpp
@@ -59,7 +59,7 @@ void generate_isolines(std::vector<Isoline>& isolines,
     if (!skip_value(i, except_vector))
     {
       Isoline isoline;
-      isoline.qid = fmt::format(pattern, i);
+      isoline.qid = fmt::format(fmt::runtime(pattern), i);
       isoline.value = i;
       isolines.push_back(isoline);
 
@@ -75,7 +75,7 @@ void apply_autoqid(std::vector<Isoline>& isolines, const std::string& pattern)
   for (auto& isoline : isolines)
   {
     if (!pattern.empty() && isoline.qid.empty())
-      isoline.qid = fmt::format(pattern, isoline.value);
+      isoline.qid = fmt::format(fmt::runtime(pattern), isoline.value);
     boost::replace_all(isoline.qid, ".", ",");  // replace decimal dots with ,
   }
 }
@@ -90,7 +90,7 @@ void apply_autoclass(std::vector<Isoline>& isolines, const std::string& pattern)
   {
     if (isoline.attributes.value("class").empty())
     {
-      auto name = fmt::format(pattern, isoline.value);
+      auto name = fmt::format(fmt::runtime(pattern), isoline.value);
       boost::replace_all(name, ".", ",");  // replace decimal dots with ,
       isoline.attributes.add("class", name);
     }


### PR DESCRIPTION
Compatibility fixes for:
- c++ 20 support by format library (requires fmt::runtime(fmt) to be used when fmt is not constexpr)
- In newer GDAL versions OGRGeometry::getSpatialRefeference returns const pointer